### PR TITLE
docs: Fix plugins resync method

### DIFF
--- a/docs/modules/plugins/scom.md
+++ b/docs/modules/plugins/scom.md
@@ -85,6 +85,6 @@ containers:
 #### Example
 
 ```bash
-curl --request POST "https://hostname:8443/api/plugins/scom/resync" \
+curl --request GET "https://hostname:8443/api/plugins/scom/resync" \
   --header "Accept: application/json"
 ```


### PR DESCRIPTION
As you can see in
- https://github.com/centreon/centreon-gorgone/blob/master/gorgone/modules/plugins/scom/hooks.pm#L33
- https://github.com/centreon/centreon-gorgone/blob/master/gorgone/modules/plugins/newtest/hooks.pm#L33

/resync path waits for a GET request, not POST.