### PR TITLE
fix(core): correct source script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,10 @@
 ##
 ##    For information : infos@centreon.com
 #
+# @TODO
+# - add the silent mode install
+# - add the upgrade  mode
+# - add the kill and clean system
 
 #----
 ## define the available options and usage of the script

--- a/install.sh
+++ b/install.sh
@@ -228,8 +228,8 @@ copy_and_modify_rights "$BASE_DIR/contrib" "gorgone_config_init.pl" "$GORGONE_BI
 
 ## Recursively copy perl files
 cp -R "$BASE_DIR/gorgone" "$GORGONE_PERL"
-${CHMOD} -R "775" "$GORGONE_PERL"
-${CHOWN} -R "$GORGONE_USER:$GORGONE_GROUP" "$GORGONE_PERL"
+${CHMOD} -R "775" "$GORGONE_PERL/gorgone"
+${CHOWN} -R "$GORGONE_USER:$GORGONE_GROUP" "$GORGONE_PERL/gorgone"
 
 #----
 ## starting the service

--- a/install.sh
+++ b/install.sh
@@ -176,6 +176,15 @@ if [ "$binary_fail" -eq 1 ] ; then
 	exit 1
 fi
 
+echo "$line"
+echo -e "\tChecking the required users"
+echo "$line"
+
+## create gorgone user
+check_gorgone_group
+check_gorgone_user
+
+
 echo -e "\n$line"
 echo -e "\tChecking the mandatory folders"
 echo -e "$line"
@@ -194,14 +203,6 @@ locate_cron_d
 locate_logrotate_d
 locate_system_d
 locate_sysconfig
-
-echo "$line"
-echo -e "\tChecking the required users"
-echo "$line"
-
-## create gorgone user
-check_gorgone_group
-check_gorgone_user
 
 echo -e "\n$line"
 echo -e "\tAdding Gorgone user to the mandatory folders"
@@ -252,7 +253,8 @@ ${CAT} << __EOT__
 #                          -----------------------                            #
 #                                                                             #
 #           Please add the configuration in a file in the folder :            #
-#                               $GORGONE_ETC                                  #
+#                           $GORGONE_ETC/config.d                             #
+#                     Then start the gorgoned.service                         #
 #                                                                             #
 #                You can read the documentation available here :              #
 #      https://github.com/centreon/centreon-gorgone/blob/master/README.md     #

--- a/sourceInstall/functions
+++ b/sourceInstall/functions
@@ -518,8 +518,16 @@ locate_gorgone_etcdir() {
     GORGONE_ETC=`trim ${GORGONE_ETC%/}`
     export GORGONE_ETC
     log "VALUE OF" "GORGONE_ETC folder = $GORGONE_ETC"
+
     # create the sub-folder for specific config files
     dir_test_create "$GORGONE_ETC/config.d"
+
+    # modify rights
+    ${CHOWN} -R "$GORGONE_USER:$GORGONE_GROUP" "$GORGONE_ETC"
+    if [ $? -ne 0 ] ; then
+        echo_failure "$(gettext "Cannot modify the owner of the files in $GORGONE_ETC folder")" "$fail"
+        return 1
+    fi
 }
 
 #----

--- a/sourceInstall/functions
+++ b/sourceInstall/functions
@@ -866,12 +866,10 @@ install_init_service() {
     fi
 
     if [ "$OS" = "DEBIAN" ] ; then
-        systemctl start $service
         systemctl enable $service
     elif [ "$OS" = "SUSE" ] ; then
         chkconfig --add $service
     elif [ "$OS" = "REDHAT" ] ; then
-        systemctl start $service
         systemctl enable $service
     elif [ "$OS" = "FREEBSD" ] ; then
         echo_info "You must configure your /etc/rc.conf with: ${service}_enable=YES"
@@ -1030,6 +1028,6 @@ copy_and_modify_rights() {
         return 1
     fi
 
-    echo_success "Modify rights on $filename" "$ok"
+    echo_success "Creating and adding rights on $filename" "$ok"
     return 0
 }


### PR DESCRIPTION
Moved the user and group creation sooner in the script
Removed the recursive ownership on the perl folder instead of only in the perl/gorgone one
Added rights on the configuration sub folder and files
Removed the failing service start as no required configuration is provided at the end of the script. The customer needs to add its own file