### PR TITLE
fix(core): fix sysconfig hardcoded path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -228,6 +228,9 @@ if [ $? -ne 0 ] ; then
     echo_failure "$(gettext "Cannot modify the owner of the files in $GORGONE_ETC folder")" "$fail"
 fi
 
+# modify the gorgoned file to take in account
+change_environment_file_path
+
 ## Copy the files in destination folders and modify rights
 copy_and_modify_rights "$BASE_DIR/config/systemd" "gorgoned-service" "$SYSTEM_D" "gorgoned.service" "664"
 copy_and_modify_rights "$BASE_DIR/config/systemd" "gorgoned-sysconfig" "$SYSCONFIG" "gorgoned" "664"

--- a/install.sh
+++ b/install.sh
@@ -228,7 +228,7 @@ if [ $? -ne 0 ] ; then
     echo_failure "$(gettext "Cannot modify the owner of the files in $GORGONE_ETC folder")" "$fail"
 fi
 
-# modify the gorgoned file to take in account
+# modify the gorgoned file to take in account the chosen user path
 change_environment_file_path
 
 ## Copy the files in destination folders and modify rights

--- a/sourceInstall/functions
+++ b/sourceInstall/functions
@@ -861,10 +861,12 @@ install_init_service() {
 
     if [ "$OS" = "DEBIAN" ] ; then
         systemctl enable $service
+        systemctl start $service
     elif [ "$OS" = "SUSE" ] ; then
         chkconfig --add $service
     elif [ "$OS" = "REDHAT" ] ; then
         systemctl enable $service
+        systemctl start $service
     elif [ "$OS" = "FREEBSD" ] ; then
         echo_info "You must configure your /etc/rc.conf with: ${service}_enable=YES"
     else
@@ -872,6 +874,15 @@ install_init_service() {
         return 1
     fi
     return 0
+}
+
+#----
+## Change gorgone service "environment file" value
+## replace the default sysconfig path with the chosen custom path
+## @Globals	DEFAULT_SYSCONFIG, SYSCONFIG
+#----
+change_environment_file_path() {
+    sed -i -e "s,$DEFAULT_SYSCONFIG,$SYSCONFIG,g" "$BASE_DIR/config/systemd/gorgoned-service"
 }
 
 #----


### PR DESCRIPTION
Replace gorgoned.service's environmentFile path value, by the one chosen by the user
To avoid this kind of error on debian :
![image](https://user-images.githubusercontent.com/34628915/76971711-d539c800-692d-11ea-918b-486e2dc6a7a5.png)

eg: on Debian the **/etc/sysconfig** folder doesn't exist and the required folder is **/etc/default**

the file is modified before being copied to the destination and its rights being modified
https://github.com/centreon/centreon-gorgone/blob/master/config/systemd/gorgoned-service