### PR TITLE
fix(spec): require bzcat(bzip2) for anomaly detection module

### DIFF
--- a/packaging/centreon-gorgone.spectemplate
+++ b/packaging/centreon-gorgone.spectemplate
@@ -9,6 +9,7 @@ Source0:    %{name}-%{version}.tar.gz
 BuildArch:  noarch
 BuildRoot:  %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
+Requires:   bzip2
 Requires:   perl-CryptX
 Requires:   perl(Schedule::Cron)
 Requires:   perl(ZMQ::LibZMQ4)


### PR DESCRIPTION
bzcat is part of bzip2 and mandatory for Anomaly Detection module to store predictions:

echo -n '' | base64 -d | bzcat -d > /etc/centreon-engine//anomaly/x.json