### PR TITLE
fix(api) Replace the API version 'beta' by 'latest'

### DIFF
--- a/install/src/centreon-api.yaml
+++ b/install/src/centreon-api.yaml
@@ -1,7 +1,7 @@
 gorgone:
   tpapi:
     - name: centreonv2
-      base_url: "http://127.0.0.1/centreon/api/beta/"
+      base_url: "http://127.0.0.1/centreon/api/latest/"
       username: admin
       password: centreon
     - name: clapi

--- a/packaging/centreon-api.yaml
+++ b/packaging/centreon-api.yaml
@@ -1,7 +1,7 @@
 gorgone:
   tpapi:
     - name: centreonv2
-      base_url: "http://127.0.0.1/centreon/api/beta/"
+      base_url: "http://127.0.0.1/centreon/api/latest/"
       username: admin
       password: centreon
     - name: clapi


### PR DESCRIPTION
On the 'develop' branch the v2 APIs use the new version 'v21.10' or 'latest'. The 'beta' version is no longer valid.