### PR TITLE
enh(mbi): add etl status action

### DIFF
--- a/contrib/mbi/centreonBIETL
+++ b/contrib/mbi/centreonBIETL
@@ -31,7 +31,7 @@ sub new {
     );
 
     bless $self, $class;
-    
+
     $self->{moptions}->{rebuild} = 0;
     $self->{moptions}->{daily} = 0;
     $self->{moptions}->{import} = 0;
@@ -46,19 +46,20 @@ sub new {
     $self->{moptions}->{nopurge} = 0;
 
     $self->add_options(
-        'url:s' => \$self->{url},
-        'r'     => \$self->{moptions}->{rebuild},
-        'd'     => \$self->{moptions}->{daily},
-        'I'     => \$self->{moptions}->{import},
-        'D'     => \$self->{moptions}->{dimensions},
-        'E'     => \$self->{moptions}->{event},
-        'P'     => \$self->{moptions}->{perfdata},
-        's:s'   => \$self->{moptions}->{start},
-        'e:s'   => \$self->{moptions}->{end},
-        'c'     => \$self->{moptions}->{create_tables},
-        'i'     => \$self->{moptions}->{ignore_databin},
-        'C'     => \$self->{moptions}->{centreon_only},
-        'p'     => \$self->{moptions}->{nopurge}
+        'url:s'  => \$self->{url},
+        'status' => \$self->{status},
+        'r'      => \$self->{moptions}->{rebuild},
+        'd'      => \$self->{moptions}->{daily},
+        'I'      => \$self->{moptions}->{import},
+        'D'      => \$self->{moptions}->{dimensions},
+        'E'      => \$self->{moptions}->{event},
+        'P'      => \$self->{moptions}->{perfdata},
+        's:s'    => \$self->{moptions}->{start},
+        'e:s'    => \$self->{moptions}->{end},
+        'c'      => \$self->{moptions}->{create_tables},
+        'i'      => \$self->{moptions}->{ignore_databin},
+        'C'      => \$self->{moptions}->{centreon_only},
+        'p'      => \$self->{moptions}->{nopurge}
     );
     return $self;
 }
@@ -69,6 +70,8 @@ sub init {
 
     $self->{url} = 'http://127.0.0.1:8085' if (!defined($self->{url}) || $self->{url} eq '');
     $self->{http} = gorgone::class::http::http->new(logger => $self->{logger});
+
+    return if (defined($self->{status}));
 
     my $utils = gorgone::modules::centreon::mbi::libs::Utils->new($self->{logger});
     if ($utils->checkBasicOptions($self->{moptions}) == 1) {
@@ -209,12 +212,116 @@ sub get_etl_log {
     }
 }
 
+sub get_etl_status {
+    my ($self) = @_;
+
+    my ($code, $content) = $self->{http}->request(
+        http_backend => 'curl',
+        method => 'GET',
+        hostname => '',
+        full_url => $self->{url} . '/api/centreon/mbietl/status',
+        header => [
+            'Accept-Type: application/json; charset=utf-8',
+            'Content-Type: application/json; charset=utf-8',
+        ],
+        curl_opt => ['CURLOPT_SSL_VERIFYPEER => 0', 'CURLOPT_POSTREDIR => CURL_REDIR_POST_ALL'],
+        warning_status => '',
+        unknown_status => '',
+        critical_status => ''
+    );
+
+    if ($self->{http}->get_code() < 200 || $self->{http}->get_code() >= 300) {
+        $self->{logger}->writeLogError("Login error [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "']");
+        exit(1);
+    }
+
+    my $decoded = $self->json_decode(content => $content);
+    if (!defined($decoded->{token})) {
+        $self->{logger}->writeLogError('cannot get token');
+        exit(1);
+    }
+
+    my $token = $decoded->{token};
+    my $log_id;
+    my $result;
+
+    while (1) {
+        my $get_param = [];
+        if (defined($log_id)) {
+            $get_param = ['id=' . $log_id];
+        }
+
+        my ($code, $content) = $self->{http}->request(
+            http_backend => 'curl',
+            method => 'GET',
+            hostname => '',
+            full_url => $self->{url} . '/api/log/' . $token,
+            get_param => $get_param,
+            header => [
+                'Accept-Type: application/json; charset=utf-8'
+            ],
+            curl_opt => ['CURLOPT_SSL_VERIFYPEER => 0', 'CURLOPT_POSTREDIR => CURL_REDIR_POST_ALL'],
+            warning_status => '',
+            unknown_status => '',
+            critical_status => ''
+        );
+
+        if ($self->{http}->get_code() < 200 || $self->{http}->get_code() >= 300) {
+            $self->{logger}->writeLogError("Login error [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "']");
+            exit(1);
+        }
+
+        my $decoded = $self->json_decode(content => $content);
+        if (!defined($decoded->{data})) {
+            $self->{logger}->writeLogError("Cannot get log information");
+            exit(1);
+        }
+
+        my $stop = 0;
+        foreach (@{$decoded->{data}}) {
+            my $data = $self->json_decode(content => $_->{data});
+            next if (defined($log_id) && $log_id >= $_->{id});
+            $log_id = $_->{id};
+
+            if ($_->{code} == 1) {
+                $self->{logger}->writeLogError('cannot get etl status');
+                exit(1);
+            } elsif ($_->{code} == 2) {
+                $result = $data;
+                $stop = 1;
+            }
+        }
+
+        last if ($stop == 1);
+        sleep(2);
+    }
+
+    print "ETL status: $result->{statusStr}\n";
+    if ($result->{statusStr} ne 'ready') {
+        print "planning: $result->{planningStr}\n";
+        foreach ('import', 'dimensions', 'event', 'perfdata') {
+            next if (!defined($result->{sections}->{$_}));
+
+            print "    $_ status: $result->{sections}->{$_}->{statusStr}";
+            if (defined($result->{sections}->{$_}->{steps_total})) {
+                print " ($result->{sections}->{$_}->{steps_executed}/$result->{sections}->{$_}->{steps_total})";
+            }
+            print "\n";
+        }
+    }
+}
+
 sub run {
     my $self = shift;
 
     $self->SUPER::run();
-    $self->run_etl();
-    $self->get_etl_log();
+
+    if (defined($self->{status})) {
+        $self->get_etl_status();
+    } else {
+        $self->run_etl();
+        $self->get_etl_log();
+    }
 }
 
 __END__

--- a/gorgone/modules/centreon/mbi/etl/hooks.pm
+++ b/gorgone/modules/centreon/mbi/etl/hooks.pm
@@ -31,6 +31,7 @@ use constant NAME => 'mbietl';
 use constant EVENTS => [
     { event => 'CENTREONMBIETLRUN', uri => '/run', method => 'POST' },
     { event => 'CENTREONMBIETLKILL', uri => '/kill', method => 'GET' },
+    { event => 'CENTREONMBIETLSTATUS', uri => '/status', method => 'GET' },
     { event => 'CENTREONMBIETLLISTENER' },
     { event => 'CENTREONMBIETLREADY' }
 ];


### PR DESCRIPTION
## Description

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [X] 21.04.x
- [X] 21.10.x
- [X] 22.04.x
- [X] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

With the following command:
```
$ perl centreonBIETL --status
ETL status: running
planning: ok
    import status: ok
    dimensions status: ok
    event status: running (737/738)
    perfdata status: ok
```

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
