### PR TITLE
Force lowercase to comply with Debian packages

### DIFF
--- a/contrib/gorgone_install_plugins.pl
+++ b/contrib/gorgone_install_plugins.pl
@@ -50,7 +50,7 @@ if ($type eq 'rpm') {
 } elsif ($type eq 'deb') {
     $command = 'apt-get -y install';
     foreach (@$plugins) {
-        $command .= " '" . $_ . "-*'"
+        $command .= " '" . lc($_) . "-*'"
     }
 }
 $command .= ' 2>&1';


### PR DESCRIPTION
## Description

On CentOS a plugin package name contains uppercases while it's not possible on Debian systems. 

centreon-plugin-Network-Cisco-Standard-Snmp vs centreon-plugin-network-cisco-standard-snmp

This is a basic fix to lowercase the plugin requirement definition from the pack. 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

On a debian central server with pollers, enable automatic installation of plugins. Install the Pack, export your configuration and check that the plugin has successfully been installed. 

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
