### PR TITLE
Adding some debug for plugin auto install

### DIFF
--- a/contrib/gorgone_install_plugins.pl
+++ b/contrib/gorgone_install_plugins.pl
@@ -56,8 +56,10 @@ if ($type eq 'rpm') {
 $command .= ' 2>&1';
 
 my $output = `$command`;
-if ($? == -1) {
-    print "failed to execute: $!\n";
+my $exit = $? >> 8;
+
+if ($? == -1 || $exit == 100) {
+    print "failed to execute: $output\n";
     exit(1);
 } elsif ($? & 127) {
     printf "child died with signal %d, %s coredump\n",
@@ -65,6 +67,5 @@ if ($? == -1) {
     exit(1);
 }
 
-my $exit = $? >> 8;
 print "succeeded command (code: $exit): " . $output;
 exit(0);

--- a/contrib/gorgone_install_plugins.pl
+++ b/contrib/gorgone_install_plugins.pl
@@ -56,10 +56,8 @@ if ($type eq 'rpm') {
 $command .= ' 2>&1';
 
 my $output = `$command`;
-my $exit = $? >> 8;
-
-if ($? == -1 || $exit == 100) {
-    print "failed to execute: $output\n";
+if ($? == -1) {
+    print "failed to execute: $!\n";
     exit(1);
 } elsif ($? & 127) {
     printf "child died with signal %d, %s coredump\n",
@@ -67,5 +65,6 @@ if ($? == -1 || $exit == 100) {
     exit(1);
 }
 
+my $exit = $? >> 8;
 print "succeeded command (code: $exit): " . $output;
 exit(0);

--- a/gorgone/modules/core/action/class.pm
+++ b/gorgone/modules/core/action/class.pm
@@ -248,7 +248,8 @@ sub install_plugins {
         redirect_stderr => 1,
         logger => $self->{logger}
     );
-    if ($error != 0) {
+    if ($error != 0 || $return_code != 0) {
+        $self->{logger}->writeLogDebug("[action] error during install. Command output: [\"$stdout\"]");
         return (-1, 'install plugins command issue: ' . $stdout);
     }
 

--- a/gorgone/modules/core/action/class.pm
+++ b/gorgone/modules/core/action/class.pm
@@ -248,8 +248,8 @@ sub install_plugins {
         redirect_stderr => 1,
         logger => $self->{logger}
     );
-    if ($error != 0 || $return_code != 0) {
-        $self->{logger}->writeLogDebug("[action] error during install. Command output: [\"$stdout\"]");
+    $self->{logger}->writeLogDebug("[action] install plugins. Command output: [\"$stdout\"]");
+    if ($error != 0) {
         return (-1, 'install plugins command issue: ' . $stdout);
     }
 


### PR DESCRIPTION
## Description

Adding debug for plugin auto install when it fails in gorgone logs when debug is enabled.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Add debug for Gorgone. 
Try to install plugin that you know will fail eventually.
Check gorgone logs.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
